### PR TITLE
Feat: Add GitHub Actions workflow to validate PR titles

### DIFF
--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,25 @@
+name: PR Title Checker
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  title-validation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Validate PR Title
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          echo "Checking PR Title: $PR_TITLE"
+          if [[ ! "$PR_TITLE" =~ ^(Feat|Fix|Chore|Docs):\ .+ ]]; then
+            echo "❌ Invalid PR Title: '$PR_TITLE'"
+            echo "PR titles must follow the format: 'Feat: Description', 'Fix: Description', 'Chore: Description', or 'Docs: Description'"
+            exit 1
+          else
+            echo "✅ PR Title is valid: '$PR_TITLE'"
+          fi


### PR DESCRIPTION


This pull request introduces a GitHub Actions workflow (pr-title-checker.yml) that automatically validates the titles of pull requests when they are opened, edited, reopened, or synchronized.

Maintaining a consistent format for PR titles is crucial for effective project management and code review processes. This workflow ensures that all PR titles adhere to our project's naming conventions, enhancing clarity and consistency across the repository. It eliminates the need for manual oversight by automating the validation process, helping contributors follow established naming conventions.

Validation Rules:

Titles must start with one of the following prefixes: Feat:, Fix:, Chore:, or Docs:
Followed by a space and a descriptive title.
If a title does not comply with these rules, the workflow will fail and provide feedback to the contributor.